### PR TITLE
Fix: Prevenire eroare KeyError: 0 în senzorul ROBOR

### DIFF
--- a/custom_components/cursbnr/sensor.py
+++ b/custom_components/cursbnr/sensor.py
@@ -533,24 +533,18 @@ class DobandaRobor(BaseBnrSensor):
     def native_value(self):
         """Returnează valoarea principală a senzorului (data extragerii)."""
         json_data = self.coordinator.data
-
-        # Ne asigurăm că extragem o listă; dacă "robor" lipsește, returnăm listă goală
         robor_data = json_data.get("robor", [])
 
-        # Verificare robustă: trebuie să fie listă ȘI să nu fie goală
+        # FIX: Verificăm dacă lista are elemente înainte de a cere indexul [0]
         if not isinstance(robor_data, list) or len(robor_data) == 0:
-            _LOGGER.error("Datele ROBOR sunt invalide sau goale pentru senzorul %s.", self._attr_name)
+            _LOGGER.warning("Datele ROBOR sunt goale sau invalide pentru %s", self._attr_name)
             return None
 
-        # Acum suntem siguri că robor_data[0] există
-        primul_element = robor_data[0]
-
-        # Verificăm dacă elementul este un dicționar înainte de .get()
-        if isinstance(primul_element, dict):
-            data_extragere = primul_element.get("Data")
-            if data_extragere:
-                _LOGGER.debug("Valoarea principală a senzorului %s este: %s", self._attr_name, data_extragere)
-                return data_extragere
+        # Acum putem lua data în siguranță
+        data_extragere = robor_data[0].get("Data")
+        if data_extragere:
+            _LOGGER.debug("Valoarea principală a senzorului %s este data: %s", self._attr_name, data_extragere)
+            return data_extragere
 
         return None
 

--- a/custom_components/cursbnr/sensor.py
+++ b/custom_components/cursbnr/sensor.py
@@ -533,19 +533,25 @@ class DobandaRobor(BaseBnrSensor):
     def native_value(self):
         """Returnează valoarea principală a senzorului (data extragerii)."""
         json_data = self.coordinator.data
+
+        # Ne asigurăm că extragem o listă; dacă "robor" lipsește, returnăm listă goală
         robor_data = json_data.get("robor", [])
 
-        if not robor_data:
-            _LOGGER.error("Nu există date în JSON pentru senzorul %s.", self._attr_name)
+        # Verificare robustă: trebuie să fie listă ȘI să nu fie goală
+        if not isinstance(robor_data, list) or len(robor_data) == 0:
+            _LOGGER.error("Datele ROBOR sunt invalide sau goale pentru senzorul %s.", self._attr_name)
             return None
 
-        # Luăm data din primul element al listei (cel mai nou)
-        data_extragere = robor_data[0].get("Data")
-        if data_extragere:
-            _LOGGER.debug("Valoarea principală (native_value) a senzorului %s este data: %s", self._attr_name, data_extragere)
-            return data_extragere
+        # Acum suntem siguri că robor_data[0] există
+        primul_element = robor_data[0]
 
-        _LOGGER.error("Nu am găsit data pentru senzorul %s.", self._attr_name)
+        # Verificăm dacă elementul este un dicționar înainte de .get()
+        if isinstance(primul_element, dict):
+            data_extragere = primul_element.get("Data")
+            if data_extragere:
+                _LOGGER.debug("Valoarea principală a senzorului %s este: %s", self._attr_name, data_extragere)
+                return data_extragere
+
         return None
 
     @property


### PR DESCRIPTION
Problemă: Integrarea genera o eroare de tip KeyError: 0 în sensor.py (linia 543) în momentele în care datele returnate de coordonator pentru ROBOR erau incomplete sau aveau o structură neașteptată (de exemplu, o listă goală sau un obiect invalid). Acest lucru ducea la oprirea actualizării senzorului.

Soluție: Am implementat o validare mai robustă pentru variabila robor_data înainte de a încerca accesarea elementelor prin index:

Se verifică dacă robor_data este într-adevăr o listă (isinstance).

Se verifică dacă lista are cel puțin un element (len > 0) înainte de a accesa robor_data[0].

Se verifică dacă primul element este un dicționar înainte de a folosi metoda .get().

Impact: Această modificare elimină crash-urile logate în Home Assistant și permite integrării să gestioneze elegant situațiile în care sursa externă (BNR) nu furnizează date valide temporar.